### PR TITLE
Change the timing of storing scroll view properties

### DIFF
--- a/Source/PullToRefreshView.swift
+++ b/Source/PullToRefreshView.swift
@@ -88,8 +88,6 @@ public class PullToRefreshView: UIView {
         
         if let scrollView = superView as? UIScrollView {
             scrollView.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &kvoContext)
-            scrollViewBounces = scrollView.bounces
-            scrollViewInsets = scrollView.contentInset
         }
     }
     
@@ -168,6 +166,9 @@ public class PullToRefreshView: UIView {
         self.arrow.hidden = true
         
         if let scrollView = superview as? UIScrollView {
+            scrollViewBounces = scrollView.bounces
+            scrollViewInsets = scrollView.contentInset
+            
             var insets = scrollView.contentInset
             insets.top += self.frame.size.height
             scrollView.contentOffset.y = self.previousOffset


### PR DESCRIPTION
Using PullToRefreshSwift with UITableViewController, the navigation bar appear over the table view after refresh. UITableViewController seems has not set up table view's properties at viewDidLoad.