### PR TITLE
[modify] delete console print

### DIFF
--- a/Source/PullToRefreshView.swift
+++ b/Source/PullToRefreshView.swift
@@ -172,8 +172,7 @@ open class PullToRefreshView: UIView {
             if !self.pull {
                 return
             }
-            print(offsetY)
-            print(self.frame.size.height)
+
             if offsetY < -self.frame.size.height {
                 // pulling or refreshing
                 if scrollView.isDragging == false && self.state != .refreshing { //release the finger


### PR DESCRIPTION
This framework is printing scrollView.contentOffset.y and self.frame.size.height to the console.
This often gets in the way. So, delete print().
