### PR TITLE
Add a public initializer to PullToRefreshOption

### DIFF
--- a/Source/PullToRefreshOption.swift
+++ b/Source/PullToRefreshOption.swift
@@ -17,8 +17,15 @@ struct PullToRefreshConst {
 }
 
 public struct PullToRefreshOption {
-    public var backgroundColor = UIColor.clear
-    public var indicatorColor = UIColor.gray
-    public var autoStopTime: Double = 0 // 0 is not auto stop
-    public var fixedSectionHeader = false  // Update the content inset for fixed section headers
+    public var backgroundColor: UIColor
+    public var indicatorColor: UIColor
+    public var autoStopTime: Double // 0 is not auto stop
+    public var fixedSectionHeader: Bool // Update the content inset for fixed section headers
+    
+    public init(backgroundColor: UIColor = .clear, indicatorColor: UIColor = .gray, autoStopTime: Double = 0, fixedSectionHeader: Bool = false) {
+        self.backgroundColor = backgroundColor
+        self.indicatorColor = indicatorColor
+        self.autoStopTime = autoStopTime
+        self.fixedSectionHeader = fixedSectionHeader
+    }
 }


### PR DESCRIPTION
PullToRefreshOption initializer is inaccessible from external projects on latest version 3.0.1 because its protection level is 'internal'. 
So I fixed it by adding a 'public' initializer to PullToRefreshOption.