### PR TITLE
Remove the 'scrollViewBounces' property that is unnecessary and causes bugs from PullToRefreshView

### DIFF
--- a/Source/PullToRefreshView.swift
+++ b/Source/PullToRefreshView.swift
@@ -25,7 +25,6 @@ open class PullToRefreshView: UIView {
     fileprivate var backgroundView: UIView
     fileprivate var arrow: UIImageView
     fileprivate var indicator: UIActivityIndicatorView
-    fileprivate var scrollViewBounces: Bool = false
     fileprivate var scrollViewInsets: UIEdgeInsets = UIEdgeInsets.zero
     fileprivate var refreshCompletion: ((Void) -> Void)?
     fileprivate var pull: Bool = true
@@ -216,7 +215,6 @@ open class PullToRefreshView: UIView {
         guard let scrollView = superview as? UIScrollView else {
             return
         }
-        scrollViewBounces = scrollView.bounces
         scrollViewInsets = scrollView.contentInset
         
         var insets = scrollView.contentInset
@@ -249,7 +247,7 @@ open class PullToRefreshView: UIView {
         guard let scrollView = superview as? UIScrollView else {
             return
         }
-        scrollView.bounces = self.scrollViewBounces
+        scrollView.bounces = true
         let duration = PullToRefreshConst.animationDuration
         UIView.animate(withDuration: duration,
                                    animations: {


### PR DESCRIPTION
The 'scrollViewBounces' that is a property of the PullToRefreshView is used for saving `scrollView.bounces` of super view before animating.
But super view of the PullToRefreshView cannot do 'PullToRefresh' if the its `scrollView.bounces` is false. 
So `scrollView.bounces` of super view is always true before animating.

In addition, the 'scrollViewBounces' causes a bug that the UITableView cannot do 'PullToRefresh' in my project.

So I remove the 'scrollViewBounces' from the PullToRefreshView.
Please check my modifications.