### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ iOS Simple PullToRefresh Library.
 
 ![sample](Screenshots/PullToRefreshSwift.gif)
 
-##Installation
+## Installation
 
-####CocoaPods
+#### CocoaPods
 ```
 pod 'PullToRefreshSwift'
 ```
 
-####Manually
+#### Manually
 Add the following files to your project. 
 `pulltorefresharrow.png`
 `PullToRefreshView.swift`
@@ -31,9 +31,9 @@ Add the following files to your project.
 `UIScrollViewExtension.swift`
 
 
-##Usage
+## Usage
 
-###Setup
+### Setup
 
 In your UIViewController Including UITableView, UICollectionView, UIScrollView:
 ```swift


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
