### PR TITLE
Impact feedback generator

### DIFF
--- a/Source/PullToRefreshView.swift
+++ b/Source/PullToRefreshView.swift
@@ -262,7 +262,7 @@ open class PullToRefreshView: UIView {
     fileprivate func arrowRotation() {
         UIView.animate(withDuration: 0.2, delay: 0, options:[], animations: {
             // -0.0000001 for the rotation direction control
-            self.arrow.transform = CGAffineTransform(rotationAngle: CGFloat(M_PI-0.0000001))
+            self.arrow.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi-0.0000001))
         }, completion:nil)
     }
     

--- a/Source/PullToRefreshView.swift
+++ b/Source/PullToRefreshView.swift
@@ -261,6 +261,11 @@ open class PullToRefreshView: UIView {
     
     fileprivate func arrowRotation() {
         UIView.animate(withDuration: 0.2, delay: 0, options:[], animations: {
+            if #available(iOS 10.0, *) {
+                let generator = UIImpactFeedbackGenerator(style: .light)
+                generator.impactOccurred()
+            }
+
             // -0.0000001 for the rotation direction control
             self.arrow.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi-0.0000001))
         }, completion:nil)


### PR DESCRIPTION
The annoying `M_PI` warning was removed replacing the `M_PI` to `Double.pi`.

I added `UIImpactFeedbackGenerator` at the moment of pull to imitate the gesture from `UIRefreshControl` only on a iPhone 7 or iPhone 7 Plus using the Taptic Engine.